### PR TITLE
Update JS SDK

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ bitcore.versionGuard = function(version) {
     var message = 'More than one instance of bitcore-lib found. ' +
       'Please make sure to require bitcore-lib and check that submodules do' +
       ' not also include their own bitcore-lib dependency.';
-    throw new Error(message);
+    //throw new Error(message); nah we good on error throwing.
   }
 };
 bitcore.versionGuard(global._bitcore);

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -129,7 +129,7 @@ function removeNetwork(network) {
 addNetwork({
   name: 'livenet',
   alias: 'mainnet',
-  pubkeyhash: 0x30,
+  pubkeyhash: 0x1e,
   privatekey: 0x9e,
   scripthash: 0x33,
   xpubkey: 0x0488b21e,

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -130,7 +130,7 @@ addNetwork({
   name: 'livenet',
   alias: 'mainnet',
   pubkeyhash: 0x30,
-  privatekey: 0x80,
+  privatekey: 0x9e,
   scripthash: 0x33,
   xpubkey: 0x0488b21e,
   xprivkey: 0x0488ade4,

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -154,6 +154,31 @@ addNetwork({
 var livenet = get('livenet');
 
 addNetwork({
+  name: 'zcoinnet',
+  alias: 'xzcmainnet',
+  pubkeyhash: 0x52, // 82
+  privatekey: 0xd2, // 210
+  scripthash: 0x07, // 7
+  xpubkey: 0x0488b21e,
+  xprivkey: 0x0488ade4,
+  networkMagic: 0xe3d9fef1,
+  port: 8168,
+  dnsSeeds: [
+    'sf1.zcoin.io',
+    'sf2.zcoin.io',
+    'london.zcoin.io',
+    'singapore.zcoin.io',
+    'nyc.zcoin.io',
+  ]
+});
+
+/**
+ * @instance
+ * @member Networks#livenet
+ */
+var zcoinnet = get('zcoinnet'); //FIXME UPDATE FOR LTC
+
+addNetwork({
   name: 'testnet',
   alias: 'regtest',
   pubkeyhash: 0x6f,
@@ -262,6 +287,7 @@ module.exports = {
   remove: removeNetwork,
   defaultNetwork: livenet,
   livenet: livenet,
+  zcoinnet: zcoinnet,
   mainnet: livenet,
   testnet: testnet,
   get: get,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bitcore-lib",
+  "name": "xvg-bitcore-lib",
   "version": "0.15.0",
   "description": "A pure and powerful JavaScript Verge library.",
   "author": "BitPay <dev@bitpay.com>",


### PR DESCRIPTION
Here is a PR that I needed for the following:

1. Allow multiple bitcore libs to be loaded
2. Following Verge prefix reqs

Not sure if this is useful to you, but it might nice of you to change the name of the repo to xvg-bitcore-lib and perhaps publish it to npm.

P.S. If you want to tip me in XVG for this: D9we3rQT48kXYzNgLdRztzNrNo5GvqqDUk